### PR TITLE
Adjust skills size

### DIFF
--- a/src/components/Skills/SkillItem.tsx
+++ b/src/components/Skills/SkillItem.tsx
@@ -51,20 +51,29 @@ const liStyles = (iconColor: string, iconBgColor: string) => {
     box-shadow: 2px 2px 5px 4px #ddd;
     transition: all 0.3s ease-in-out;
 
-    h4 > span {
-      position: relative;
+    h4 {
+      margin: 1rem 0 0.5rem;
+      font-size: 0.9rem;
 
-      &::after {
-        content: '';
-        position: absolute;
-        background-color: ${iconColor};
-        bottom: -8px;
-        left: -5%;
-        width: 100%;
-        height: 2px;
-        transform: scale(0, 1);
-        transform-origin: left;
-        transition: all 0.3s ease-in-out;
+      @media (min-width: ${breakpoints.sm}px) {
+        font-size: 1rem;
+      }
+
+      & > span {
+        position: relative;
+
+        &::after {
+          content: '';
+          position: absolute;
+          background-color: ${iconColor};
+          bottom: -8px;
+          left: -5%;
+          width: 100%;
+          height: 2px;
+          transform: scale(0, 1);
+          transform-origin: left;
+          transition: all 0.3s ease-in-out;
+        }
       }
     }
 
@@ -72,12 +81,13 @@ const liStyles = (iconColor: string, iconBgColor: string) => {
     svg {
       margin: 16px auto;
       padding: 0;
-      width: 64px;
+      width: 48px;
       background-color: ${iconBgColor};
       fill: ${iconColor};
       transition: all 0.3s ease-out;
 
       @media (min-width: ${breakpoints.sm}px) {
+        width: 64px;
         background-color: ${ItemBgColor};
         fill: black;
       }

--- a/src/components/Skills/SkillList.tsx
+++ b/src/components/Skills/SkillList.tsx
@@ -37,9 +37,6 @@ const SkillList: React.FC<Margin & SkillList> = ({ margin, title, list }) => {
 };
 const skillTitleStyle = css`
   margin-bottom: 1rem;
-  @media (min-width: ${breakpoints.sm}px) {
-    margin-bottom: 2rem;
-  }
 `;
 
 // 親からマージンの指定を受ける

--- a/src/components/Skills/SkillList.tsx
+++ b/src/components/Skills/SkillList.tsx
@@ -61,12 +61,17 @@ const marginStyle = ({ margin }: Margin) => {
 const ulStyles = css`
   padding: 1rem;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
 
   @media (min-width: ${breakpoints.sm}px) {
-    padding: 0;
     grid-template-columns: repeat(4, 1fr);
+  }
+  @media (min-width: ${breakpoints.lg}px) {
+    grid-template-columns: repeat(5, 1fr);
+  }
+  @media (min-width: ${breakpoints.xl}px) {
+    grid-template-columns: repeat(6, 1fr);
   }
 `;
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,17 +30,11 @@ const IndexPage: React.FC = () => {
 };
 
 const wrapper = css`
-  max-width: 480px;
+  max-width: 95%;
   margin: 0 auto 64px;
 
-  @media (min-width: ${breakpoints.sm}px) {
-    max-width: ${breakpoints.sm}px;
-  }
-  @media (min-width: ${breakpoints.md}px) {
-    max-width: ${breakpoints.md}px;
-  }
-  @media (min-width: ${breakpoints.lg}px) {
-    max-width: ${breakpoints.lg}px;
+  @media (min-width: ${breakpoints.xl}px) {
+    max-width: ${breakpoints.xl}px;
   }
 `;
 


### PR DESCRIPTION
#24 
SkillList の列数とアイコンサイズを以下のように変更  

- スマホ: 3 列 48px
- PC: 画面幅に応じて 4~6 列 64px